### PR TITLE
週番号のカスタマイズ

### DIFF
--- a/src/Gantt.tsx
+++ b/src/Gantt.tsx
@@ -1,5 +1,5 @@
 import { useSize } from 'ahooks'
-import { Dayjs } from 'dayjs'
+import type { Dayjs } from 'dayjs'
 import React, { useContext, useEffect, useImperativeHandle, useMemo, useRef } from 'react'
 import Chart from './components/chart'
 import Divider from './components/divider'
@@ -12,11 +12,12 @@ import TimeAxis from './components/time-axis'
 import TimeAxisScaleSelect from './components/time-axis-scale-select'
 import TimeIndicator from './components/time-indicator'
 import { BAR_HEIGHT, ROW_HEIGHT, TABLE_INDENT } from './constants'
-import Context, { GanttContext } from './context'
+import type { GanttContext } from './context'
+import Context from './context'
 import './Gantt.less'
 import { zhCN } from './locales'
 import GanttStore from './store'
-import { DefaultRecordType, Gantt } from './types'
+import type { DefaultRecordType, Gantt } from './types'
 
 const prefixCls = 'gantt'
 
@@ -66,7 +67,7 @@ export interface GanttProps<RecordType = DefaultRecordType> {
    * 自定义日期筛选维度
    */
   customSights?: Gantt.SightConfig[]
-  locale?: GanttLocale;
+  locale?: GanttLocale
 
   /**
    * 隐藏左侧表格
@@ -79,32 +80,33 @@ export interface GanttRef {
 }
 
 export interface GanttLocale {
-  today: string;
-  day: string;
-  days: string;
-  week: string;
-  month: string;
-  quarter: string;
-  halfYear: string;
-  firstHalf: string;
-  secondHalf: string,
+  today: string
+  day: string
+  days: string
+  week: string
+  week_in_month: string
+  month: string
+  quarter: string
+  halfYear: string
+  firstHalf: string
+  secondHalf: string
   majorFormat: {
-    day: string;
-    week: string;
-    month: string;
-    quarter: string;
-    halfYear: string;
-  },
+    day: string
+    week: string
+    month: string
+    quarter: string
+    halfYear: string
+  }
   minorFormat: {
-    day: string;
-    week: string;
-    month: string;
-    quarter: string;
-    halfYear: string;
+    day: string
+    week: string
+    month: string
+    quarter: string
+    halfYear: string
   }
 }
 
-export const defaultLocale: GanttLocale = {...zhCN};
+export const defaultLocale: GanttLocale = { ...zhCN }
 
 const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<RecordType>) => {
   const {
@@ -137,7 +139,7 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
     renderRightText,
     onExpand,
     customSights = [],
-    locale = {...defaultLocale},
+    locale = { ...defaultLocale },
     hideTable = false,
   } = props
 

--- a/src/Gantt.tsx
+++ b/src/Gantt.tsx
@@ -93,6 +93,7 @@ export interface GanttLocale {
   majorFormat: {
     day: string
     week: string
+    week_in_month: string
     month: string
     quarter: string
     halfYear: string
@@ -100,6 +101,7 @@ export interface GanttLocale {
   minorFormat: {
     day: string
     week: string
+    week_in_month: string
     month: string
     quarter: string
     halfYear: string

--- a/src/components/time-axis/index.less
+++ b/src/components/time-axis/index.less
@@ -53,6 +53,16 @@
     line-height: 28px;
     color: #202d40;
     text-decoration: none;
+    border-width: 1px;
+    border-style: solid;
+    border-color: #f0f0f0;
+    background-color: transparent;
+    border-bottom: none;
+    border-left: none;
+    cursor: pointer;
+    outline: none;
+    padding: 0;
+    appearance: none;
     &:hover {
       text-decoration: underline;
     }

--- a/src/components/time-axis/index.less
+++ b/src/components/time-axis/index.less
@@ -14,7 +14,6 @@
     top: 0;
     left: 0;
     height: 56px;
-    pointer-events: none;
     user-select: none;
     will-change: transform;
   }
@@ -53,6 +52,10 @@
     font-size: 12px;
     line-height: 28px;
     color: #202d40;
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
     &.weekends {
       background-color: hsla(0, 0%, 96.9%, 0.5);
     }

--- a/src/components/time-axis/index.tsx
+++ b/src/components/time-axis/index.tsx
@@ -60,19 +60,20 @@ const TimeAxis: React.FC = () => {
             </div>
           ))}
           {minorList.map(item => (
-            <div
+            <a
               key={item.key}
               className={classNames(`${prefixClsTimeAxis}-minor`)}
               style={{ width: item.width, left: item.left }}
+              href='#'
             >
-              <div
+              <span
                 className={classNames(`${prefixClsTimeAxis}-minor-label`, {
                   [`${prefixClsTimeAxis}-today`]: getIsToday(item),
                 })}
               >
                 {item.label}
-              </div>
-            </div>
+              </span>
+            </a>
           ))}
         </div>
       </div>

--- a/src/components/time-axis/index.tsx
+++ b/src/components/time-axis/index.tsx
@@ -60,11 +60,11 @@ const TimeAxis: React.FC = () => {
             </div>
           ))}
           {minorList.map(item => (
-            <a
+            <button
               key={item.key}
+              type='button'
               className={classNames(`${prefixClsTimeAxis}-minor`)}
               style={{ width: item.width, left: item.left }}
-              href='#'
             >
               <span
                 className={classNames(`${prefixClsTimeAxis}-minor-label`, {
@@ -73,7 +73,7 @@ const TimeAxis: React.FC = () => {
               >
                 {item.label}
               </span>
-            </a>
+            </button>
           ))}
         </div>
       </div>

--- a/src/locales/en-us.ts
+++ b/src/locales/en-us.ts
@@ -5,6 +5,7 @@ export const enUS: GanttLocale = Object.freeze({
   day: 'Day',
   days: 'Days',
   week: 'Week',
+  week_in_month: 'Week in month',
   month: 'Month',
   quarter: 'Quarter',
   halfYear: 'Half year',
@@ -13,6 +14,7 @@ export const enUS: GanttLocale = Object.freeze({
   majorFormat: {
     day: 'YYYY, MMMM',
     week: 'YYYY, MMMM',
+    week_in_month: 'YYYY, MMMM',
     month: 'YYYY',
     quarter: 'YYYY',
     halfYear: 'YYYY',
@@ -20,6 +22,7 @@ export const enUS: GanttLocale = Object.freeze({
   minorFormat: {
     day: 'D',
     week: 'wo [week]',
+    week_in_month: '',
     month: 'MMMM',
     quarter: '[Q]Q',
     halfYear: 'YYYY-',

--- a/src/locales/en-us.ts
+++ b/src/locales/en-us.ts
@@ -1,27 +1,27 @@
-import { GanttLocale } from "../Gantt";
+import type { GanttLocale } from '../Gantt'
 
 export const enUS: GanttLocale = Object.freeze({
-    today: "Today",
-    day: "Day",
-    days: "Days",
-    week: "Week",
-    month: "Month",
-    quarter: "Quarter",
-    halfYear: "Half year",
-    firstHalf: "First half",
-    secondHalf: "Second half",
-    majorFormat: {
-      day: "YYYY, MMMM",
-      week: "YYYY, MMMM",
-      month: "YYYY",
-      quarter: "YYYY",
-      halfYear: "YYYY",
-    },
-    minorFormat: {
-      day: "D",
-      week: "wo [week]",
-      month: "MMMM",
-      quarter: "[Q]Q",
-      halfYear: "YYYY-",
-    }
-  });
+  today: 'Today',
+  day: 'Day',
+  days: 'Days',
+  week: 'Week',
+  month: 'Month',
+  quarter: 'Quarter',
+  halfYear: 'Half year',
+  firstHalf: 'First half',
+  secondHalf: 'Second half',
+  majorFormat: {
+    day: 'YYYY, MMMM',
+    week: 'YYYY, MMMM',
+    month: 'YYYY',
+    quarter: 'YYYY',
+    halfYear: 'YYYY',
+  },
+  minorFormat: {
+    day: 'D',
+    week: 'wo [week]',
+    month: 'MMMM',
+    quarter: '[Q]Q',
+    halfYear: 'YYYY-',
+  }
+})

--- a/src/locales/zh-cn.ts
+++ b/src/locales/zh-cn.ts
@@ -5,6 +5,7 @@ export const zhCN: GanttLocale = Object.freeze({
   day: '日视图',
   days: '天数',
   week: '周视图',
+  week_in_month: '周视图',
   month: '月视图',
   quarter: '季视图',
   halfYear: '年视图',
@@ -13,6 +14,7 @@ export const zhCN: GanttLocale = Object.freeze({
   majorFormat: {
     day: 'YYYY年MM月',
     week: 'YYYY年MM月',
+    week_in_month: 'YYYY年MM月',
     month: 'YYYY年',
     quarter: 'YYYY年',
     halfYear: 'YYYY年',
@@ -20,6 +22,7 @@ export const zhCN: GanttLocale = Object.freeze({
   minorFormat: {
     day: 'YYYY-MM-D',
     week: 'YYYY-w周',
+    week_in_month: 'YYYY-w周',
     month: 'YYYY-MM月',
     quarter: 'YYYY-第Q季',
     halfYear: 'YYYY-',

--- a/src/locales/zh-cn.ts
+++ b/src/locales/zh-cn.ts
@@ -1,27 +1,27 @@
-import { GanttLocale } from "../Gantt";
+import type { GanttLocale } from '../Gantt'
 
 export const zhCN: GanttLocale = Object.freeze({
-  today: "今天",
-  day: "日视图",
-  days: "天数",
-  week: "周视图",
-  month: "月视图",
-  quarter: "季视图",
-  halfYear: "年视图",
-  firstHalf: "上半年",
-  secondHalf: "下半年",
+  today: '今天',
+  day: '日视图',
+  days: '天数',
+  week: '周视图',
+  month: '月视图',
+  quarter: '季视图',
+  halfYear: '年视图',
+  firstHalf: '上半年',
+  secondHalf: '下半年',
   majorFormat: {
-    day: "YYYY年MM月",
-    week: "YYYY年MM月",
-    month: "YYYY年",
-    quarter: "YYYY年",
-    halfYear: "YYYY年",
+    day: 'YYYY年MM月',
+    week: 'YYYY年MM月',
+    month: 'YYYY年',
+    quarter: 'YYYY年',
+    halfYear: 'YYYY年',
   },
   minorFormat: {
-    day: "YYYY-MM-D",
-    week: "YYYY-w周",
-    month: "YYYY-MM月",
-    quarter: "YYYY-第Q季",
-    halfYear: "YYYY-",
+    day: 'YYYY-MM-D',
+    week: 'YYYY-w周',
+    month: 'YYYY-MM月',
+    quarter: 'YYYY-第Q季',
+    halfYear: 'YYYY-',
   }
-});
+})

--- a/src/store.ts
+++ b/src/store.ts
@@ -39,6 +39,11 @@ export const getViewTypeList = locale => {
       value: Gantt.ESightValues.week,
     },
     {
+      type: 'week_in_month',
+      label: locale.week_in_month,
+      value: Gantt.ESightValues.week_in_month,
+    },
+    {
       type: 'month',
       label: locale.month,
       value: Gantt.ESightValues.month,
@@ -357,6 +362,7 @@ class GanttStore {
     const majorFormatMap: { [key in Gantt.Sight]: string } = {
       day: this.locale.majorFormat.day,
       week: this.locale.majorFormat.week,
+      week_in_month: this.locale.majorFormat.week_in_month,
       month: this.locale.majorFormat.month,
       quarter: this.locale.majorFormat.quarter,
       halfYear: this.locale.majorFormat.halfYear,
@@ -367,19 +373,19 @@ class GanttStore {
     const format = majorFormatMap[type]
 
     const getNextDate = (start: Dayjs) => {
-      if (type === 'day' || type === 'week') return start.add(1, 'month')
+      if (type === 'day' || type === 'week' || type === 'week_in_month') return start.add(1, 'month')
 
       return start.add(1, 'year')
     }
 
     const getStart = (date: Dayjs) => {
-      if (type === 'day' || type === 'week') return date.startOf('month')
+      if (type === 'day' || type === 'week' || type === 'week_in_month') return date.startOf('month')
 
       return date.startOf('year')
     }
 
     const getEnd = (date: Dayjs) => {
-      if (type === 'day' || type === 'week') return date.endOf('month')
+      if (type === 'day' || type === 'week' || type === 'week_in_month') return date.endOf('month')
 
       return date.endOf('year')
     }
@@ -432,6 +438,7 @@ class GanttStore {
     const minorFormatMap = {
       day: this.locale.minorFormat.day,
       week: this.locale.minorFormat.week,
+      week_in_month: this.locale.minorFormat.week_in_month,
       month: this.locale.minorFormat.month,
       quarter: this.locale.minorFormat.quarter,
       halfYear: this.locale.minorFormat.halfYear,
@@ -449,6 +456,9 @@ class GanttStore {
           return start.add(1, 'day')
         },
         week() {
+          return start.add(1, 'week')
+        },
+        week_in_month() {
           return start.add(1, 'week')
         },
         month() {
@@ -470,6 +480,9 @@ class GanttStore {
           return date.startOf('day')
         },
         week() {
+          return date.weekday(1).hour(0).minute(0).second(0)
+        },
+        week_in_month() {
           return date.weekday(1).hour(0).minute(0).second(0)
         },
         month() {
@@ -495,6 +508,9 @@ class GanttStore {
         week() {
           return start.weekday(7).hour(23).minute(59).second(59)
         },
+        week_in_month() {
+          return start.weekday(7).hour(23).minute(59).second(59)
+        },
         month() {
           return start.endOf('month')
         },
@@ -513,7 +529,7 @@ class GanttStore {
     const getMinorKey = (date: Dayjs) => {
       if (this.sightConfig.type === 'halfYear')
         return date.format(format) + (fstHalfYear.has(date.month()) ? this.locale.firstHalf : this.locale.secondHalf)
-      if (this.sightConfig.type === 'week') {
+      if (this.sightConfig.type === 'week_in_month') {
         const weekInMonth = Math.ceil((date.date() - dayjs(date).startOf('month').day() + 1) / 7)
         return `${weekInMonth}w`
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
-import { Dayjs } from 'dayjs'
-import React from 'react'
+import type { Dayjs } from 'dayjs'
+import type React from 'react'
 
 export type DefaultRecordType = Record<string, any>
 export namespace Gantt {
@@ -26,12 +26,13 @@ export namespace Gantt {
     startDate: Dayjs
     endDate: Dayjs
   }
-  export type Sight = 'day' | 'week' | 'month' | 'quarter' | 'halfYear'
+  export type Sight = 'day' | 'week' | 'week_in_month' |'month' | 'quarter' | 'halfYear'
   export type MoveType = 'left' | 'right' | 'move' | 'create'
 
   export enum ESightValues {
     day = 2880,
     week = 3600,
+    week_in_month = 3600,
     month = 14400,
     quarter = 86400,
     halfYear = 115200,

--- a/website/demo/basic.en-US.tsx
+++ b/website/demo/basic.en-US.tsx
@@ -14,7 +14,7 @@ function createData(len: number) {
   for (let i = 0; i < len; i++) {
     result.push({
       id: i,
-      name: 'Title' + i,
+      name: `Title${i}`,
       startDate: dayjs().subtract(-i, 'day').format('YYYY-MM-DD'),
       endDate: dayjs().add(i, 'day').format('YYYY-MM-DD'),
     })
@@ -36,6 +36,8 @@ const App = () => {
             width: 100,
           },
         ]}
+        unit="week_in_month"
+        showUnitSwitch={false}
         locale={enUS}
         onUpdate={async (row, startDate, endDate) => {
           console.log('update', row, startDate, endDate)


### PR DESCRIPTION
## 変更内容

- `ween_in_month` のパターンを追加して月の週番号と年の週番号を選択できるようにする https://github.com/betterbound/react-gantt/commit/52745416ee11785d969671557aea440c059db974
  - `ween_in_month` 月の週番号
  - `week` 年の週番号
- 週番号をクリッカブルにする https://github.com/betterbound/react-gantt/commit/daeb6b52b923b9327ecfe8efaeee3d3722c12b52
  - 一旦、クリッカブルにするだけで `href` の対応はしていません
