### PR TITLE
一番左の列に前月の1週目を表示

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -164,7 +164,7 @@ class GanttStore {
   isRestDay = isRestDay
 
   getStartDate() {
-    return dayjs().subtract(15, 'day').toString()
+    return dayjs().subtract(10, 'day').toString()
   }
  
   getFirstDayOfLastMonth() {

--- a/src/store.ts
+++ b/src/store.ts
@@ -164,7 +164,11 @@ class GanttStore {
   isRestDay = isRestDay
 
   getStartDate() {
-    return dayjs().subtract(10, 'day').toString()
+    return dayjs().subtract(15, 'day').toString()
+  }
+ 
+  getFirstDayOfLastMonth() {
+    return dayjs().subtract(1, 'month').startOf('month').toString()
   }
 
   setIsRestDay(function_: (date: string) => boolean) {
@@ -269,7 +273,7 @@ class GanttStore {
     const target = find(this.viewTypeList, { type })
     if (target) {
       this.sightConfig = target
-      this.setTranslateX(dayjs(this.getStartDate()).valueOf() / (target.value * 1000))
+      this.setTranslateX(dayjs(this.getFirstDayOfLastMonth()).valueOf() / (target.value * 1000))
     }
   }
 
@@ -899,5 +903,6 @@ class GanttStore {
     return target === now
   }
 }
+
 
 export default GanttStore


### PR DESCRIPTION
## 変更内容

- 前月の1週目を返す関数を作成して適用

## どうやるのか

- `pnpm run start:website` でサイトを起動
- ガントチャートの表示を確認
- 一番左の列に前月の1週目が表示されているか

## 備考

ローカルでご確認いただく時にもし上手く行かない場合、[こちらのPRの「備考」](https://github.com/betterbound/react-gantt/pull/1)にある方法を試してみてください 🙇‍♀️ 