### PR TITLE
月ごとの週表示の時、週の横幅を狭くする

### DIFF
--- a/src/Gantt.tsx
+++ b/src/Gantt.tsx
@@ -238,7 +238,6 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
           {!hideTable && <TableBody />}
           <Chart />
         </main>
-        {!hideTable && <Divider />}
         {showBackToday && <TimeIndicator />}
         {showUnitSwitch && <TimeAxisScaleSelect />}
         <ScrollBar />

--- a/src/store.ts
+++ b/src/store.ts
@@ -273,7 +273,10 @@ class GanttStore {
     const target = find(this.viewTypeList, { type })
     if (target) {
       this.sightConfig = target
-      this.setTranslateX(dayjs(this.getFirstDayOfLastMonth()).valueOf() / (target.value * 1000))
+      if(target.type === 'week_in_month')
+        this.setTranslateX(dayjs(this.getFirstDayOfLastMonth()).valueOf() / (target.value * 5000))
+      else
+        this.setTranslateX(dayjs(this.getStartDate()).valueOf() / (target.value * 1000))
     }
   }
 
@@ -346,7 +349,10 @@ class GanttStore {
 
   // 1px对应的毫秒数
   @computed get pxUnitAmp() {
-    return this.sightConfig.value * 1000
+    let pxUnit = this.sightConfig.value * 1000
+    if(this.sightConfig.type === 'week_in_month') pxUnit = this.sightConfig.value * 5000
+
+    return pxUnit
   }
 
   /** 当前开始时间毫秒数 */

--- a/src/store.ts
+++ b/src/store.ts
@@ -605,6 +605,7 @@ class GanttStore {
     const map = {
       day: dayRect,
       week: weekRect,
+      week_in_month: weekRect,
       month: weekRect,
       quarter: monthRect,
       halfYear: monthRect,


### PR DESCRIPTION
## 変更内容

- 月ごとの週表示の時、週の横幅を狭くする
- サイドバーを閉じるボタンを非表示にする

<img width="1083" alt="Screenshot 2023-06-08 at 17 03 01" src="https://github.com/betterbound/react-gantt/assets/108515953/5a084447-ccf2-4dbb-a1a4-88553894ca5c">


## なぜこの変更をするのか

- 幅が広いと4ヶ月分を画面で表示できないので。（見切れる）

## どうやるのか

- Basic Component で週の幅が狭くなっっているか

## 備考

4ヶ月分の表示はチャートの横幅の調整になるので、yarikiri の方で調整します。