### PR TITLE
チャートにアイコンの表示を可能にする

### DIFF
--- a/src/components/task-bar/index.tsx
+++ b/src/components/task-bar/index.tsx
@@ -116,6 +116,7 @@ const TaskBar: React.FC<TaskBarProps> = ({ data }) => {
     return `${daysWidth} ${daysWidth > 1 ? locale.days : locale.day}`
   }, [translateX, width, moveCalc, translateX])
 
+  const icon = data.record.icon
   return (
     <div
       role='none'
@@ -214,23 +215,24 @@ const TaskBar: React.FC<TaskBarProps> = ({ data }) => {
           reachEdge={reachEdge}
           onBeforeResize={handleBeforeResize('move')}
         >
-          {renderBar ? (
-            renderBar(data, {
-              width: width + 1,
-              height: barHeight + 1,
-            })
-          ) : (
-            <svg
-              xmlns='http://www.w3.org/2000/svg'
-              version='1.1'
-              width={width + 1}
-              height={barHeight + 1}
-              viewBox={`0 0 ${width + 1} ${barHeight + 1}`}
-            >
-              <path
-                fill={record.backgroundColor || (getBarColor && getBarColor(record).backgroundColor) || themeColor[0]}
-                stroke={record.borderColor || (getBarColor && getBarColor(record).borderColor) || themeColor[1]}
-                d={`
+          {icon || <>
+            { (renderBar ? (
+              renderBar(data, {
+                width: width + 1,
+                height: barHeight + 1,
+              })
+            ) : (
+              <svg
+                xmlns='http://www.w3.org/2000/svg'
+                version='1.1'
+                width={width + 1}
+                height={barHeight + 1}
+                viewBox={`0 0 ${width + 1} ${barHeight + 1}`}
+              >
+                <path
+                  fill={record.backgroundColor || (getBarColor && getBarColor(record).backgroundColor) || themeColor[0]}
+                  stroke={record.borderColor || (getBarColor && getBarColor(record).borderColor) || themeColor[1]}
+                  d={`
               M${width - 2},0.5
               l-${width - 5},0
               c-0.41421,0 -0.78921,0.16789 -1.06066,0.43934
@@ -251,17 +253,19 @@ const TaskBar: React.FC<TaskBarProps> = ({ data }) => {
               c-0.03256,-0.38255 -0.20896,-0.724 -0.47457,-0.97045
               c-0.26763,-0.24834 -0.62607,-0.40013 -1.01995,-0.40013z
             `}
-              />
-            </svg>
-          )}
+                />
+              </svg>
+            ))}
+          </>
+          }
         </DragResize>
       </div>
-      {(allowDrag || disabled || alwaysShowTaskBar) && (
+      {!icon && (allowDrag || disabled || alwaysShowTaskBar) && (
         <div className={`${prefixClsTaskBar}-label`} style={{ left: width / 2 - 10 }}>
           {days}
         </div>
       )}
-      {(stepGesture === 'moving' || allowDrag || alwaysShowTaskBar) && (
+      {!icon &&(stepGesture === 'moving' || allowDrag || alwaysShowTaskBar) && (
         <>
           <div className={`${prefixClsTaskBar}-date-text`} style={{ left: width + 16 }}>
             {renderRightText ? renderRightText(data) : dateTextFormat(translateX + width + moveCalc)}

--- a/website/demo/basic.en-US.tsx
+++ b/website/demo/basic.en-US.tsx
@@ -7,6 +7,7 @@ interface Data {
   name: string
   startDate: string
   endDate: string
+  icon?: JSX.Element
 }
 
 function createData(len: number) {
@@ -17,6 +18,7 @@ function createData(len: number) {
       name: `Title${i}`,
       startDate: dayjs().subtract(-i, 'day').format('YYYY-MM-DD'),
       endDate: dayjs().add(i, 'day').format('YYYY-MM-DD'),
+      icon: <p>icon</p>
     })
   }
   return result


### PR DESCRIPTION
## 対応内容

Data に icon プロパティを追加するとアイコンが表示されるようにカスタマイズ

```ts
interface Data {
  id: number
  name: string
  startDate: string
  endDate: string
  icon?: JSX.Element
}
```

<img width="928" alt="Screenshot 2023-06-12 at 14 56 54" src="https://github.com/betterbound/react-gantt/assets/108515953/0d7deaac-e2b9-48a6-b0ea-ec9ff0773511">


## どうやるのか

1. http://localhost:8000/#/en-US/component へアクセス
2. Basic Component に 「icon」と表示されていることを確認
3. 他のデモのチャートバーには影響がないことを確認（Multi-level structure など）

## 備考

pタグ を icon に見立ててます。
