### PR TITLE
タスクバーに複数アイテムを表示できるようにする

### DIFF
--- a/src/components/bar-list/index.tsx
+++ b/src/components/bar-list/index.tsx
@@ -5,19 +5,26 @@ import Context from '../../context'
 import GroupBar from '../group-bar'
 import InvalidTaskBar from '../invalid-task-bar'
 import TaskBar from '../task-bar'
+import TaskBarItems from '../task-bar-items'
 
 const BarList: React.FC = () => {
   const { store } = useContext(Context)
   const barList = store.getBarList
   const { count, start } = store.getVisibleRows
   return (
-    <>
-      {barList.slice(start, start + count).map(bar => {
+    <div data-bar='BarList'>
+      {barList.slice(start, start + count).map((bar, index) => {
         if (bar._group) return <GroupBar key={bar.key} data={bar} />
+
+        if (bar.record.barItems) {
+          return bar.record.barItems.map(barItem => (
+            <TaskBarItems key={barItem.id} index={index} data={bar} barItem={barItem} />
+          ))
+        }
 
         return bar.invalidDateRange ? <InvalidTaskBar key={bar.key} data={bar} /> : <TaskBar key={bar.key} data={bar} />
       })}
-    </>
+    </div>
   )
 }
 export default observer(BarList)

--- a/src/components/task-bar-items/index.less
+++ b/src/components/task-bar-items/index.less
@@ -1,0 +1,19 @@
+@import '../../style/themes/index';
+@task-bar-prefix-cls: ~'@{gantt-prefix}-task-bar';
+
+.@{task-bar-prefix-cls} {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+
+  &-loading {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    cursor: not-allowed;
+    z-index: 9;
+  }
+}

--- a/src/components/task-bar-items/index.tsx
+++ b/src/components/task-bar-items/index.tsx
@@ -1,0 +1,54 @@
+import dayjs from 'dayjs'
+import { observer } from 'mobx-react-lite'
+import React, { useContext } from 'react'
+import Context from '../../context'
+import type { Gantt } from '../../types'
+import './index.less'
+
+interface TaskBarProps {
+  data: Gantt.Bar
+  index: number
+  barItem: {
+    id: string
+    icon: JSX.Element
+    startDate: string
+    endDate: string
+  }
+}
+
+const TaskBarItems: React.FC<TaskBarProps> = ({ data, index, barItem }) => {
+  const { store, prefixCls } = useContext(Context)
+  const { loading } = data
+
+  const prefixClsTaskBar = `${prefixCls}-task-bar`
+
+  const baseTop = store.rowHeight
+  const topStep = store.rowHeight
+
+  const valid = barItem.startDate && barItem.endDate
+  const startAmp = dayjs(barItem.startDate || 0)
+    .startOf('day')
+    .valueOf()
+  const translateX = valid ? startAmp / store.pxUnitAmp : 0
+  const translateY = baseTop + index * topStep
+
+  return (
+    <div
+      role='none'
+      className={prefixClsTaskBar}
+      style={{
+        transform: `translate(${translateX}px, ${translateY}px)`,
+      }}
+    >
+      {loading && <div className={`${prefixClsTaskBar}-loading`} />}
+      <div
+        style={{
+          transform: `translateY(50%) translateY(-${baseTop}px)`,
+        }}
+      >
+        {barItem.icon}
+      </div>
+    </div>
+  )
+}
+export default observer(TaskBarItems)

--- a/src/components/task-bar/index.tsx
+++ b/src/components/task-bar/index.tsx
@@ -6,7 +6,7 @@ import React, { useCallback, useContext, useMemo } from 'react'
 import { TOP_PADDING } from '../../constants'
 import Context from '../../context'
 import { ONE_DAY_MS } from '../../store'
-import { Gantt } from '../../types'
+import type { Gantt } from '../../types'
 import DragResize from '../drag-resize'
 import './index.less'
 
@@ -108,15 +108,14 @@ const TaskBar: React.FC<TaskBarProps> = ({ data }) => {
   // 根据不同的视图确定拖动时的单位，在任何视图下都以一天为单位
   const grid = useMemo(() => ONE_DAY_MS / store.pxUnitAmp, [store.pxUnitAmp])
 
-  const moveCalc = -(width / store.pxUnitAmp);
+  const moveCalc = -(width / store.pxUnitAmp)
 
   const days = useMemo(() => {
-    const daysWidth = Number(getDateWidth(translateX + width + moveCalc, translateX));
+    const daysWidth = Number(getDateWidth(translateX + width + moveCalc, translateX))
 
     return `${daysWidth} ${daysWidth > 1 ? locale.days : locale.day}`
   }, [translateX, width, moveCalc, translateX])
 
-  const icon = data.record.icon
   return (
     <div
       role='none'
@@ -215,24 +214,23 @@ const TaskBar: React.FC<TaskBarProps> = ({ data }) => {
           reachEdge={reachEdge}
           onBeforeResize={handleBeforeResize('move')}
         >
-          {icon || <>
-            { (renderBar ? (
-              renderBar(data, {
-                width: width + 1,
-                height: barHeight + 1,
-              })
-            ) : (
-              <svg
-                xmlns='http://www.w3.org/2000/svg'
-                version='1.1'
-                width={width + 1}
-                height={barHeight + 1}
-                viewBox={`0 0 ${width + 1} ${barHeight + 1}`}
-              >
-                <path
-                  fill={record.backgroundColor || (getBarColor && getBarColor(record).backgroundColor) || themeColor[0]}
-                  stroke={record.borderColor || (getBarColor && getBarColor(record).borderColor) || themeColor[1]}
-                  d={`
+          {renderBar ? (
+            renderBar(data, {
+              width: width + 1,
+              height: barHeight + 1,
+            })
+          ) : (
+            <svg
+              xmlns='http://www.w3.org/2000/svg'
+              version='1.1'
+              width={width + 1}
+              height={barHeight + 1}
+              viewBox={`0 0 ${width + 1} ${barHeight + 1}`}
+            >
+              <path
+                fill={record.backgroundColor || (getBarColor && getBarColor(record).backgroundColor) || themeColor[0]}
+                stroke={record.borderColor || (getBarColor && getBarColor(record).borderColor) || themeColor[1]}
+                d={`
               M${width - 2},0.5
               l-${width - 5},0
               c-0.41421,0 -0.78921,0.16789 -1.06066,0.43934
@@ -253,19 +251,17 @@ const TaskBar: React.FC<TaskBarProps> = ({ data }) => {
               c-0.03256,-0.38255 -0.20896,-0.724 -0.47457,-0.97045
               c-0.26763,-0.24834 -0.62607,-0.40013 -1.01995,-0.40013z
             `}
-                />
-              </svg>
-            ))}
-          </>
-          }
+              />
+            </svg>
+          )}
         </DragResize>
       </div>
-      {!icon && (allowDrag || disabled || alwaysShowTaskBar) && (
+      {(allowDrag || disabled || alwaysShowTaskBar) && (
         <div className={`${prefixClsTaskBar}-label`} style={{ left: width / 2 - 10 }}>
           {days}
         </div>
       )}
-      {!icon &&(stepGesture === 'moving' || allowDrag || alwaysShowTaskBar) && (
+      {(stepGesture === 'moving' || allowDrag || alwaysShowTaskBar) && (
         <>
           <div className={`${prefixClsTaskBar}-date-text`} style={{ left: width + 16 }}>
             {renderRightText ? renderRightText(data) : dateTextFormat(translateX + width + moveCalc)}

--- a/website/demo/basic.en-US.tsx
+++ b/website/demo/basic.en-US.tsx
@@ -7,7 +7,12 @@ interface Data {
   name: string
   startDate: string
   endDate: string
-  icon?: JSX.Element
+  barItems?: {
+    id: string
+    icon: JSX.Element
+    startDate: string
+    endDate: string
+  }[]
 }
 
 function createData(len: number) {
@@ -18,7 +23,34 @@ function createData(len: number) {
       name: `Title${i}`,
       startDate: dayjs().subtract(-i, 'day').format('YYYY-MM-DD'),
       endDate: dayjs().add(i, 'day').format('YYYY-MM-DD'),
-      icon: <p>icon</p>
+      barItems: [
+        {
+          id: `${i}-1`,
+          icon: <span>A</span>,
+          startDate: dayjs().subtract(-i, 'week').format('YYYY-MM-DD'),
+          endDate: dayjs().add(i, 'week').format('YYYY-MM-DD'),
+        },
+        {
+          id: `${i}-2`,
+          icon: <span>B</span>,
+          startDate: dayjs()
+            .subtract(-i - 1, 'week')
+            .format('YYYY-MM-DD'),
+          endDate: dayjs()
+            .add(i + 1, 'week')
+            .format('YYYY-MM-DD'),
+        },
+        {
+          id: `${i}-3`,
+          icon: <span>C</span>,
+          startDate: dayjs()
+            .subtract(-i - 3, 'week')
+            .format('YYYY-MM-DD'),
+          endDate: dayjs()
+            .add(i + 3, 'week')
+            .format('YYYY-MM-DD'),
+        },
+      ],
     })
   }
   return result
@@ -38,7 +70,7 @@ const App = () => {
             width: 100,
           },
         ]}
-        unit="week_in_month"
+        unit='week_in_month'
         showUnitSwitch={false}
         locale={enUS}
         onUpdate={async (row, startDate, endDate) => {


### PR DESCRIPTION
## 変更内容

- タスクバーに複数のアイテムが表示できるように変更
  - 複数アイテム用のタスクバーコンポーネントを作成 https://github.com/betterbound/react-gantt/commit/cd758c259ccc014e9ec2ff8965bfe8099a37a29d
  - 以前実装したアイコン表示のロジックを削除 https://github.com/betterbound/react-gantt/commit/7137e1c2eb706346d030cb1fd6e182e9d3719ff9
  - デモコンポーネントに適用 https://github.com/betterbound/react-gantt/commit/98a234eb77a9a7c893c193a9e805e0145371e137

<img width="1022" alt="Screenshot 2023-06-13 at 17 27 55" src="https://github.com/betterbound/react-gantt/assets/108515953/c274e7c1-98b2-4d6b-852d-d6b982fc4070">

## 確認方法

1. http://localhost:8000/#/en-US/component#component へアクセス
2. アイコンに見立てている A / B / C が同じバーに表示されていることを確認
