### PR TITLE
階層構造になった時、タスクバー上のアイテムの位置がズレるので修正

### DIFF
--- a/src/components/bar-list/index.tsx
+++ b/src/components/bar-list/index.tsx
@@ -13,14 +13,11 @@ const BarList: React.FC = () => {
   const { count, start } = store.getVisibleRows
   return (
     <div data-bar='BarList'>
-      {barList.slice(start, start + count).map((bar, index) => {
+      {barList.slice(start, start + count).map(bar => {
         if (bar._group) return <GroupBar key={bar.key} data={bar} />
 
-        if (bar.record.barItems) {
-          return bar.record.barItems.map(barItem => (
-            <TaskBarItems key={barItem.id} index={index} data={bar} barItem={barItem} />
-          ))
-        }
+        if (bar.record.barItems)
+          return bar.record.barItems.map(barItem => <TaskBarItems key={barItem.id} data={bar} barItem={barItem} />)
 
         return bar.invalidDateRange ? <InvalidTaskBar key={bar.key} data={bar} /> : <TaskBar key={bar.key} data={bar} />
       })}

--- a/src/components/task-bar-items/index.tsx
+++ b/src/components/task-bar-items/index.tsx
@@ -7,7 +7,6 @@ import './index.less'
 
 interface TaskBarProps {
   data: Gantt.Bar
-  index: number
   barItem: {
     id: string
     icon: JSX.Element
@@ -16,21 +15,17 @@ interface TaskBarProps {
   }
 }
 
-const TaskBarItems: React.FC<TaskBarProps> = ({ data, index, barItem }) => {
+const TaskBarItems: React.FC<TaskBarProps> = ({ data, barItem }) => {
   const { store, prefixCls } = useContext(Context)
-  const { loading } = data
+  const { loading, translateY } = data
 
   const prefixClsTaskBar = `${prefixCls}-task-bar`
-
-  const baseTop = store.rowHeight
-  const topStep = store.rowHeight
 
   const valid = barItem.startDate && barItem.endDate
   const startAmp = dayjs(barItem.startDate || 0)
     .startOf('day')
     .valueOf()
   const translateX = valid ? startAmp / store.pxUnitAmp : 0
-  const translateY = baseTop + index * topStep
 
   return (
     <div
@@ -41,13 +36,7 @@ const TaskBarItems: React.FC<TaskBarProps> = ({ data, index, barItem }) => {
       }}
     >
       {loading && <div className={`${prefixClsTaskBar}-loading`} />}
-      <div
-        style={{
-          transform: `translateY(50%) translateY(-${baseTop}px)`,
-        }}
-      >
-        {barItem.icon}
-      </div>
+      {barItem.icon}
     </div>
   )
 }

--- a/website/demo/basic.en-US.tsx
+++ b/website/demo/basic.en-US.tsx
@@ -13,6 +13,7 @@ interface Data {
     startDate: string
     endDate: string
   }[]
+  children: any
 }
 
 function createData(len: number) {
@@ -23,32 +24,48 @@ function createData(len: number) {
       name: `Title${i}`,
       startDate: dayjs().subtract(-i, 'day').format('YYYY-MM-DD'),
       endDate: dayjs().add(i, 'day').format('YYYY-MM-DD'),
-      barItems: [
+      children: [
         {
-          id: `${i}-1`,
-          icon: <span>A</span>,
-          startDate: dayjs().subtract(-i, 'week').format('YYYY-MM-DD'),
-          endDate: dayjs().add(i, 'week').format('YYYY-MM-DD'),
-        },
-        {
-          id: `${i}-2`,
-          icon: <span>B</span>,
-          startDate: dayjs()
-            .subtract(-i - 1, 'week')
-            .format('YYYY-MM-DD'),
-          endDate: dayjs()
-            .add(i + 1, 'week')
-            .format('YYYY-MM-DD'),
-        },
-        {
-          id: `${i}-3`,
-          icon: <span>C</span>,
-          startDate: dayjs()
-            .subtract(-i - 3, 'week')
-            .format('YYYY-MM-DD'),
-          endDate: dayjs()
-            .add(i + 3, 'week')
-            .format('YYYY-MM-DD'),
+          id: i,
+          name: `Title${i}`,
+          startDate: dayjs().subtract(-i, 'day').format('YYYY-MM-DD'),
+          endDate: dayjs().add(i, 'day').format('YYYY-MM-DD'),
+          children: [
+            {
+              id: i,
+              name: `Title${i}`,
+              startDate: dayjs().subtract(-i, 'day').format('YYYY-MM-DD'),
+              endDate: dayjs().add(i, 'day').format('YYYY-MM-DD'),
+              barItems: [
+                {
+                  id: `${i}-1`,
+                  icon: <span>A</span>,
+                  startDate: dayjs().subtract(-i, 'week').format('YYYY-MM-DD'),
+                  endDate: dayjs().add(i, 'week').format('YYYY-MM-DD'),
+                },
+                {
+                  id: `${i}-2`,
+                  icon: <span>B</span>,
+                  startDate: dayjs()
+                    .subtract(-i - 1, 'week')
+                    .format('YYYY-MM-DD'),
+                  endDate: dayjs()
+                    .add(i + 1, 'week')
+                    .format('YYYY-MM-DD'),
+                },
+                {
+                  id: `${i}-3`,
+                  icon: <span>C</span>,
+                  startDate: dayjs()
+                    .subtract(-i - 3, 'week')
+                    .format('YYYY-MM-DD'),
+                  endDate: dayjs()
+                    .add(i + 3, 'week')
+                    .format('YYYY-MM-DD'),
+                },
+              ],
+            },
+          ],
         },
       ],
     })
@@ -57,7 +74,7 @@ function createData(len: number) {
 }
 
 const App = () => {
-  const [data, setData] = useState(createData(20))
+  const [data, setData] = useState(createData(40))
   console.log('data', data)
   return (
     <div style={{ width: '100%', height: 500 }}>


### PR DESCRIPTION
## 変更内容

階層構造の時、スクロールするとタスクバーのアイテムの縦位置がズレるので修正

<img width="755" alt="Screenshot 2023-06-13 at 23 18 00" src="https://github.com/betterbound/react-gantt/assets/108515953/7ca7a223-eb88-41a7-a62c-28ac98504eeb">

<img width="724" alt="Screenshot 2023-06-13 at 23 21 01" src="https://github.com/betterbound/react-gantt/assets/108515953/ba0159e6-4e7e-49e7-a245-4dbc6ef807d6">


## 確認方法

1. http://localhost:8000/#/en-US/component#component へアクセス
2. Basic Component で「Title39」までスクロールしても A / B / C が同じライン上に表示されている