### PR TITLE
横軸をクリックして関数を呼び出せるようonTimeAxisClick propsを追加

### DIFF
--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -7072,6 +7072,7 @@ var GanttComponent = function GanttComponent(props) {
       renderLeftText = props.renderLeftText,
       renderRightText = props.renderRightText,
       onExpand = props.onExpand,
+      onTimeAxisClick = props.onTimeAxisClick,
       _props$customSights = props.customSights,
       customSights = _props$customSights === void 0 ? [] : _props$customSights,
       _props$locale = props.locale,
@@ -7137,9 +7138,10 @@ var GanttComponent = function GanttComponent(props) {
       renderLeftText: renderLeftText,
       renderRightText: renderRightText,
       onExpand: onExpand,
+      onTimeAxisClick: onTimeAxisClick,
       hideTable: hideTable
     };
-  }, [store, getBarColor, showBackToday, showUnitSwitch, onRow, tableIndent, expandIcon, renderBar, renderInvalidBar, renderGroupBar, onBarClick, tableCollapseAble, renderBarThumb, scrollTop, alwaysShowTaskBar, renderLeftText, renderRightText, onExpand, hideTable]);
+  }, [store, getBarColor, showBackToday, showUnitSwitch, onRow, tableIndent, expandIcon, renderBar, renderInvalidBar, renderGroupBar, onBarClick, tableCollapseAble, renderBarThumb, scrollTop, alwaysShowTaskBar, renderLeftText, renderRightText, onExpand, onTimeAxisClick, hideTable]);
   return /*#__PURE__*/React.createElement(context.Provider, {
     value: ContextValue
   }, /*#__PURE__*/React.createElement(Body, null, /*#__PURE__*/React.createElement("header", null, !hideTable && /*#__PURE__*/React.createElement(TableHeader$1, null), /*#__PURE__*/React.createElement(TimeAxis$1, null)), /*#__PURE__*/React.createElement("main", {

--- a/dist/types/Gantt.d.ts
+++ b/dist/types/Gantt.d.ts
@@ -32,6 +32,7 @@ export interface GanttProps<RecordType = DefaultRecordType> {
     renderLeftText?: GanttContext<RecordType>['renderLeftText'];
     renderRightText?: GanttContext<RecordType>['renderLeftText'];
     onExpand?: GanttContext<RecordType>['onExpand'];
+    onTimeAxisClick?: GanttContext<RecordType>['onTimeAxisClick'];
     /**
      * 自定义日期筛选维度
      */

--- a/dist/types/context.d.ts
+++ b/dist/types/context.d.ts
@@ -37,6 +37,7 @@ export interface GanttContext<RecordType = DefaultRecordType> {
     renderLeftText?: (barInfo: Gantt.Bar<RecordType>) => React.ReactNode;
     renderRightText?: (barInfo: Gantt.Bar<RecordType>) => React.ReactNode;
     onExpand?: (record: Gantt.Record<RecordType>, collapsed: boolean) => void;
+    onTimeAxisClick?: (value: string) => void
     hideTable?: boolean;
 }
 declare const context: React.Context<GanttContext<DefaultRecordType>>;

--- a/src/Gantt.tsx
+++ b/src/Gantt.tsx
@@ -63,6 +63,7 @@ export interface GanttProps<RecordType = DefaultRecordType> {
   renderLeftText?: GanttContext<RecordType>['renderLeftText']
   renderRightText?: GanttContext<RecordType>['renderLeftText']
   onExpand?: GanttContext<RecordType>['onExpand']
+  onTimeAxisClick?: (value: string) => void
   /**
    * 自定义日期筛选维度
    */
@@ -140,6 +141,7 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
     renderLeftText,
     renderRightText,
     onExpand,
+    onTimeAxisClick,
     customSights = [],
     locale = { ...defaultLocale },
     hideTable = false,
@@ -201,6 +203,7 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
       renderLeftText,
       renderRightText,
       onExpand,
+      onTimeAxisClick,
       hideTable,
     }),
     [
@@ -222,6 +225,7 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
       renderLeftText,
       renderRightText,
       onExpand,
+      onTimeAxisClick,
       hideTable,
     ]
   )

--- a/src/components/time-axis/index.tsx
+++ b/src/components/time-axis/index.tsx
@@ -32,7 +32,7 @@ const TimeAxis: React.FC = () => {
   )
 
   const handleClick = useCallback((e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    onTimeAxisClick(e.currentTarget.value)
+    if (onTimeAxisClick) onTimeAxisClick(e.currentTarget.value)
   }, [onTimeAxisClick])
 
   return (

--- a/src/components/time-axis/index.tsx
+++ b/src/components/time-axis/index.tsx
@@ -33,7 +33,7 @@ const TimeAxis: React.FC = () => {
 
   const handleClick = useCallback((e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     onTimeAxisClick(e.currentTarget.value)
-  }, [])
+  }, [onTimeAxisClick])
 
   return (
     <DragResize

--- a/src/components/time-axis/index.tsx
+++ b/src/components/time-axis/index.tsx
@@ -7,7 +7,7 @@ import Context from '../../context'
 import './index.less'
 
 const TimeAxis: React.FC = () => {
-  const { store, prefixCls } = useContext(Context)
+  const { store, prefixCls, onTimeAxisClick } = useContext(Context)
   const prefixClsTimeAxis = `${prefixCls}-time-axis`
   const { sightConfig, isToday } = store
   const majorList = store.getMajorList()
@@ -30,6 +30,10 @@ const TimeAxis: React.FC = () => {
     },
     [sightConfig, isToday]
   )
+
+  const handleClick = useCallback((e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    onTimeAxisClick(e.currentTarget.value)
+  }, [])
 
   return (
     <DragResize
@@ -65,6 +69,8 @@ const TimeAxis: React.FC = () => {
               type='button'
               className={classNames(`${prefixClsTimeAxis}-minor`)}
               style={{ width: item.width, left: item.left }}
+              value={item.key}
+              onClick={handleClick}
             >
               <span
                 className={classNames(`${prefixClsTimeAxis}-minor-label`, {

--- a/src/context.ts
+++ b/src/context.ts
@@ -39,6 +39,7 @@ export interface GanttContext<RecordType = DefaultRecordType> {
   renderLeftText?: (barInfo: Gantt.Bar<RecordType>) => React.ReactNode
   renderRightText?: (barInfo: Gantt.Bar<RecordType>) => React.ReactNode
   onExpand?: (record: Gantt.Record<RecordType>, collapsed: boolean) => void
+  onTimeAxisClick?: (value: string) => void
 
   hideTable?: boolean
 }

--- a/website/demo/basic.en-US.tsx
+++ b/website/demo/basic.en-US.tsx
@@ -76,6 +76,9 @@ function createData(len: number) {
 const App = () => {
   const [data, setData] = useState(createData(40))
   console.log('data', data)
+  const handleClick = (value: string) => {
+    console.log(new Date(value))
+  }
   return (
     <div style={{ width: '100%', height: 500 }}>
       <RcGantt<Data>
@@ -104,6 +107,7 @@ const App = () => {
           })
           return true
         }}
+        onTimeAxisClick={handleClick}
       />
     </div>
   )


### PR DESCRIPTION
## 変更内容

- `onTimeAxisClick`propsが渡せるよう型やコンポーネントに追加 https://github.com/betterbound/react-gantt/commit/f0d6f74c877095e852654aa3a69b3661c0e13ff8
- 横軸をクリックしてその日付が渡るよう`TimeAxis`コンポーネントに関数を追加 https://github.com/betterbound/react-gantt/commit/b9bab7df32c34f337327a2038d3072181e8090f5
- demoで横軸をクリックしてその日付がコンソールで確認できるよう変更 https://github.com/betterbound/react-gantt/commit/f85a9f693ec83b693df00222869669833a437663

## どうやるのか

1. http://localhost:8000/#/en-US/component#basic-component にアクセスし週をクリック
2. その週の最初の日付がコンソールで確認できるか

## 備考
既存のpropsを見ながら実装してみましたがこんな感じで大丈夫でしょうか？