### PR TITLE
renderDaysTextとshowIndicatorのpropsを追加

### DIFF
--- a/src/Gantt.tsx
+++ b/src/Gantt.tsx
@@ -65,7 +65,7 @@ export interface GanttProps<RecordType = DefaultRecordType> {
   renderDaysText?: GanttContext<RecordType>['renderDaysText']
   onExpand?: GanttContext<RecordType>['onExpand']
   onTimeAxisClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
-  showIndicator?: boolean
+  showChangeBarSize?: boolean
   /**
    * 自定义日期筛选维度
    */
@@ -145,7 +145,7 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
     renderDaysText,
     onExpand,
     onTimeAxisClick,
-    showIndicator = true,
+    showChangeBarSize = true,
     customSights = [],
     locale = { ...defaultLocale },
     hideTable = false,
@@ -209,7 +209,7 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
       renderDaysText,
       onExpand,
       onTimeAxisClick,
-      showIndicator,
+      showChangeBarSize,
       hideTable,
     }),
     [
@@ -233,7 +233,7 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
       renderDaysText,
       onExpand,
       onTimeAxisClick,
-      showIndicator,
+      showChangeBarSize,
       hideTable,
     ]
   )

--- a/src/Gantt.tsx
+++ b/src/Gantt.tsx
@@ -62,6 +62,7 @@ export interface GanttProps<RecordType = DefaultRecordType> {
   alwaysShowTaskBar?: boolean
   renderLeftText?: GanttContext<RecordType>['renderLeftText']
   renderRightText?: GanttContext<RecordType>['renderLeftText']
+  renderDaysText?: GanttContext<RecordType>['renderDaysText']
   onExpand?: GanttContext<RecordType>['onExpand']
   onTimeAxisClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
   /**
@@ -140,6 +141,7 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
     alwaysShowTaskBar = true,
     renderLeftText,
     renderRightText,
+    renderDaysText,
     onExpand,
     onTimeAxisClick,
     customSights = [],
@@ -202,6 +204,7 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
       alwaysShowTaskBar,
       renderLeftText,
       renderRightText,
+      renderDaysText,
       onExpand,
       onTimeAxisClick,
       hideTable,
@@ -224,6 +227,7 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
       alwaysShowTaskBar,
       renderLeftText,
       renderRightText,
+      renderDaysText,
       onExpand,
       onTimeAxisClick,
       hideTable,

--- a/src/Gantt.tsx
+++ b/src/Gantt.tsx
@@ -65,6 +65,7 @@ export interface GanttProps<RecordType = DefaultRecordType> {
   renderDaysText?: GanttContext<RecordType>['renderDaysText']
   onExpand?: GanttContext<RecordType>['onExpand']
   onTimeAxisClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
+  showIndicator?: boolean
   /**
    * 自定义日期筛选维度
    */
@@ -144,6 +145,7 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
     renderDaysText,
     onExpand,
     onTimeAxisClick,
+    showIndicator = true,
     customSights = [],
     locale = { ...defaultLocale },
     hideTable = false,
@@ -207,6 +209,7 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
       renderDaysText,
       onExpand,
       onTimeAxisClick,
+      showIndicator,
       hideTable,
     }),
     [
@@ -230,6 +233,7 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
       renderDaysText,
       onExpand,
       onTimeAxisClick,
+      showIndicator,
       hideTable,
     ]
   )

--- a/src/components/task-bar/index.tsx
+++ b/src/components/task-bar/index.tsx
@@ -26,7 +26,7 @@ const TaskBar: React.FC<TaskBarProps> = ({ data }) => {
     renderLeftText,
     renderRightText,
     renderDaysText,
-    showIndicator
+    showChangeBarSize
   } = useContext(Context)
   const {
     width,
@@ -47,7 +47,7 @@ const TaskBar: React.FC<TaskBarProps> = ({ data }) => {
   const { selectionIndicatorTop, showSelectionIndicator, rowHeight, locale } = store
 
   const showDragBar = useMemo(() => {
-    if (!showIndicator || !showSelectionIndicator) return false
+    if (!showChangeBarSize || !showSelectionIndicator) return false
     // 差值
     const baseTop = TOP_PADDING + rowHeight / 2 - barHeight / 2
     return selectionIndicatorTop === translateY - baseTop

--- a/src/components/task-bar/index.tsx
+++ b/src/components/task-bar/index.tsx
@@ -26,6 +26,7 @@ const TaskBar: React.FC<TaskBarProps> = ({ data }) => {
     renderLeftText,
     renderRightText,
     renderDaysText,
+    showIndicator
   } = useContext(Context)
   const {
     width,
@@ -46,7 +47,7 @@ const TaskBar: React.FC<TaskBarProps> = ({ data }) => {
   const { selectionIndicatorTop, showSelectionIndicator, rowHeight, locale } = store
 
   const showDragBar = useMemo(() => {
-    if (!showSelectionIndicator) return false
+    if (!showIndicator || !showSelectionIndicator) return false
     // 差值
     const baseTop = TOP_PADDING + rowHeight / 2 - barHeight / 2
     return selectionIndicatorTop === translateY - baseTop

--- a/src/components/task-bar/index.tsx
+++ b/src/components/task-bar/index.tsx
@@ -25,6 +25,7 @@ const TaskBar: React.FC<TaskBarProps> = ({ data }) => {
     alwaysShowTaskBar,
     renderLeftText,
     renderRightText,
+    renderDaysText,
   } = useContext(Context)
   const {
     width,
@@ -258,7 +259,7 @@ const TaskBar: React.FC<TaskBarProps> = ({ data }) => {
       </div>
       {(allowDrag || disabled || alwaysShowTaskBar) && (
         <div className={`${prefixClsTaskBar}-label`} style={{ left: width / 2 - 10 }}>
-          {days}
+          {renderDaysText ? renderDaysText(data) : days}
         </div>
       )}
       {(stepGesture === 'moving' || allowDrag || alwaysShowTaskBar) && (

--- a/src/context.ts
+++ b/src/context.ts
@@ -41,6 +41,7 @@ export interface GanttContext<RecordType = DefaultRecordType> {
   renderDaysText?: (barInfo: Gantt.Bar<RecordType>) => React.ReactNode
   onExpand?: (record: Gantt.Record<RecordType>, collapsed: boolean) => void
   onTimeAxisClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
+  showIndicator?: boolean
 
   hideTable?: boolean
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -38,6 +38,7 @@ export interface GanttContext<RecordType = DefaultRecordType> {
   alwaysShowTaskBar?: boolean
   renderLeftText?: (barInfo: Gantt.Bar<RecordType>) => React.ReactNode
   renderRightText?: (barInfo: Gantt.Bar<RecordType>) => React.ReactNode
+  renderDaysText?: (barInfo: Gantt.Bar<RecordType>) => React.ReactNode
   onExpand?: (record: Gantt.Record<RecordType>, collapsed: boolean) => void
   onTimeAxisClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -41,7 +41,7 @@ export interface GanttContext<RecordType = DefaultRecordType> {
   renderDaysText?: (barInfo: Gantt.Bar<RecordType>) => React.ReactNode
   onExpand?: (record: Gantt.Record<RecordType>, collapsed: boolean) => void
   onTimeAxisClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
-  showIndicator?: boolean
+  showChangeBarSize?: boolean
 
   hideTable?: boolean
 }

--- a/website/demo/basic.en-US.tsx
+++ b/website/demo/basic.en-US.tsx
@@ -109,6 +109,7 @@ const App = () => {
         }}
         onTimeAxisClick={handleClick}
         renderDaysText={() => ''}
+        showIndicator={false}
       />
     </div>
   )

--- a/website/demo/basic.en-US.tsx
+++ b/website/demo/basic.en-US.tsx
@@ -108,6 +108,7 @@ const App = () => {
           return true
         }}
         onTimeAxisClick={handleClick}
+        renderDaysText={() => ''}
       />
     </div>
   )

--- a/website/demo/basic.en-US.tsx
+++ b/website/demo/basic.en-US.tsx
@@ -109,7 +109,7 @@ const App = () => {
         }}
         onTimeAxisClick={handleClick}
         renderDaysText={() => ''}
-        showIndicator={false}
+        showChangeBarSize={false}
       />
     </div>
   )


### PR DESCRIPTION
## 変更内容

- Barの上に表示される`〇〇Days`をカスタムできるよう`renderDaysText`propsを追加
- Barの期間を動かせるindicatorを非表示にできる`showIndicator`propsを追加

## 確認方法

- [http://localhost:8000/#/en-US/component#basic-component](http://localhost:8000/#/en-US/component#basic-component) でBarの上に`〇〇Days`が表示されていないか
- 期間変更のindicatorが非表示なっているか
- 他のコンポーネントでは今までと同じような表示になっているか

## 備考

- `showIndicator`は内部のstoreにある`showSelectionIndicator`と被るなと思いつつ、あまり良い方法思いつかなかったので別でもう一つprops定義しました