### PR TITLE
Barを動かすことができないようにcanMoveBar propsを追加

### DIFF
--- a/src/Gantt.tsx
+++ b/src/Gantt.tsx
@@ -66,6 +66,7 @@ export interface GanttProps<RecordType = DefaultRecordType> {
   onExpand?: GanttContext<RecordType>['onExpand']
   onTimeAxisClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
   showChangeBarSize?: boolean
+  canMoveBar?: boolean
   /**
    * 自定义日期筛选维度
    */
@@ -146,6 +147,7 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
     onExpand,
     onTimeAxisClick,
     showChangeBarSize = true,
+    canMoveBar = true,
     customSights = [],
     locale = { ...defaultLocale },
     hideTable = false,
@@ -210,6 +212,7 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
       onExpand,
       onTimeAxisClick,
       showChangeBarSize,
+      canMoveBar,
       hideTable,
     }),
     [
@@ -234,6 +237,7 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
       onExpand,
       onTimeAxisClick,
       showChangeBarSize,
+      canMoveBar,
       hideTable,
     ]
   )

--- a/src/context.ts
+++ b/src/context.ts
@@ -42,6 +42,7 @@ export interface GanttContext<RecordType = DefaultRecordType> {
   onExpand?: (record: Gantt.Record<RecordType>, collapsed: boolean) => void
   onTimeAxisClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
   showChangeBarSize?: boolean
+  canMoveBar?: boolean
 
   hideTable?: boolean
 }

--- a/website/demo/basic.en-US.tsx
+++ b/website/demo/basic.en-US.tsx
@@ -110,6 +110,7 @@ const App = () => {
         onTimeAxisClick={handleClick}
         renderDaysText={() => ''}
         showChangeBarSize={false}
+        canMoveBar={false}
       />
     </div>
   )


### PR DESCRIPTION
## 変更内容

- canMoveBar propsを追加
- barのレンダー部分を抜き出し`RenderBar`コンポーネントとして定義

## 確認方法

- [http://localhost:8000/#/en-US/component#basic-component](http://localhost:8000/#/en-US/component#basic-component) でbarが動かせないようになっているか
- 他のコンポーネントは今まで通り動かせるようになっているか