### PR TITLE
2つ目以降の縦軸のpadding leftを0に変更

### DIFF
--- a/src/components/table-body/index.tsx
+++ b/src/components/table-body/index.tsx
@@ -59,7 +59,7 @@ const TableRows = () => {
                   minWidth: column.minWidth,
                   maxWidth: column.maxWidth,
                   textAlign: column.align ? column.align : 'left',
-                  paddingLeft: index === 0 ? tableIndent * (bar._depth + 1) + 10 : 12,
+                  paddingLeft: index === 0 ? tableIndent * (bar._depth + 1) + 10 : 0,
                   ...column.style,
                 }}
               >


### PR DESCRIPTION
## 変更理由

- 使う側でpaddingを指定したいため

## どうやるのか

- [http://localhost:8000/#/en-US/component#customizing-table-columns](http://localhost:8000/#/en-US/component#customizing-table-columns) で2つ目以降の縦軸のpadding leftが0になっているか