### PR TITLE
成果物モジュールのガントの縦軸の各タイトルの背景色を変更できるよう実装

### DIFF
--- a/src/components/table-body/index.tsx
+++ b/src/components/table-body/index.tsx
@@ -42,7 +42,7 @@ const TableRows = () => {
           <div
             key={bar.key}
             role='none'
-            className={`${prefixClsTableBody}-row`}
+            className={`${prefixClsTableBody}-row ${bar.record.className}`}
             style={{
               height: rowHeight,
               top: (rowIndex + start) * rowHeight + TOP_PADDING,
@@ -62,7 +62,6 @@ const TableRows = () => {
                   textAlign: column.align ? column.align : 'left',
                   paddingLeft: index === 0 && tableIndent * (bar._depth + 1) + 10,
                   ...column.style,
-                  background: bar.record.className
                 }}
               >
                 {index === 0 &&

--- a/src/components/table-body/index.tsx
+++ b/src/components/table-body/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useCallback } from 'react'
+import React, { useCallback, useContext } from 'react'
 import { observer } from 'mobx-react-lite'
 import classNames from 'classnames'
 import Context from '../../context'
@@ -62,6 +62,7 @@ const TableRows = () => {
                   textAlign: column.align ? column.align : 'left',
                   paddingLeft: index === 0 && tableIndent * (bar._depth + 1) + 10,
                   ...column.style,
+                  background: bar.record.className
                 }}
               >
                 {index === 0 &&

--- a/website/demo/basic.en-US.tsx
+++ b/website/demo/basic.en-US.tsx
@@ -7,6 +7,7 @@ interface Data {
   name: string
   startDate: string
   endDate: string
+  className: string
   barItems?: {
     id: string
     icon: JSX.Element
@@ -24,18 +25,21 @@ function createData(len: number) {
       name: `Title${i}`,
       startDate: dayjs().subtract(-i, 'day').format('YYYY-MM-DD'),
       endDate: dayjs().add(i, 'day').format('YYYY-MM-DD'),
+      className: 'blue',
       children: [
         {
           id: i,
           name: `Title${i}`,
           startDate: dayjs().subtract(-i, 'day').format('YYYY-MM-DD'),
           endDate: dayjs().add(i, 'day').format('YYYY-MM-DD'),
+          className: 'gray',
           children: [
             {
               id: i,
               name: `Title${i}`,
               startDate: dayjs().subtract(-i, 'day').format('YYYY-MM-DD'),
               endDate: dayjs().add(i, 'day').format('YYYY-MM-DD'),
+              className: 'white',
               barItems: [
                 {
                   id: `${i}-1`,


### PR DESCRIPTION
## やったこと
- 表題通り
## 確認事項
- [ ] http://localhost:8000/#/~demos/website-basic.en-usで背景色が分かれるようになっていることを確認
![Screenshot 2023-11-07 at 0 39 55](https://github.com/betterbound/react-gantt/assets/90598123/d5631648-80e0-4526-85fe-ba41a1147148)
