### PR TITLE
ReactNodeを許容するように型を修正した

### DIFF
--- a/dist/types/types.d.ts
+++ b/dist/types/types.d.ts
@@ -89,7 +89,7 @@ export declare namespace Gantt {
         maxWidth?: number;
         flex?: number;
         name: string;
-        label: string;
+        label: string | React.ReactNode;
         style?: Object;
         render?: (item: Record<RecordType>) => React.ReactNode;
         align?: ColumnAlign;

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,7 +94,7 @@ export namespace Gantt {
     maxWidth?: number
     flex?: number
     name: string
-    label: string
+    label: string | React.ReactNode
     style?: Object
     render?: (item: Record<RecordType>) => React.ReactNode
     align?: ColumnAlign

--- a/website/component.en-US.md
+++ b/website/component.en-US.md
@@ -70,7 +70,7 @@ export interface Column<RecordType = DefaultRecordType> {
   maxWidth?: number
   flex?: number
   name: string
-  label: string
+  label: string | React.ReactNode
   style?: Object
   render?: (item: Record<RecordType>) => React.ReactNode
   align?: ColumnAlign

--- a/website/component.md
+++ b/website/component.md
@@ -70,7 +70,7 @@ export interface Column<RecordType = DefaultRecordType> {
   maxWidth?: number
   flex?: number
   name: string
-  label: string
+  label: string | React.ReactNode
   style?: Object
   render?: (item: Record<RecordType>) => React.ReactNode
   align?: ColumnAlign


### PR DESCRIPTION
## やったこと
- 表題通り

## 確認事項
- [x] RcGanttのlabelで`ReactNode`が扱えていることを確認

![Screenshot 2023-12-26 at 1 11 05](https://github.com/betterbound/react-gantt/assets/90598123/f7c9b44a-b0e9-4fb6-88fb-9849a8686147)
