### PR TITLE
テーブルのサイズを可変にする

### DIFF
--- a/dist/types/Gantt.d.ts
+++ b/dist/types/Gantt.d.ts
@@ -47,6 +47,10 @@ export interface GanttProps<RecordType = DefaultRecordType> {
      * 隐藏左侧表格
      */
     hideTable?: boolean;
+    tableSize?: {
+      minWidth?: number
+      maxWidth?: number
+    }
 }
 export interface GanttRef {
     backToday: () => void;

--- a/dist/types/context.d.ts
+++ b/dist/types/context.d.ts
@@ -44,6 +44,10 @@ export interface GanttContext<RecordType = DefaultRecordType> {
     timeAxisMinorStyle?: {};
     allowAddBar?: boolean;
     hideTable?: boolean;
+    tableSize?: {
+        minWidth?: number;
+        maxWidth?: number;
+    }
 }
 declare const context: React.Context<GanttContext<DefaultRecordType>>;
 export default context;

--- a/src/Gantt.tsx
+++ b/src/Gantt.tsx
@@ -262,6 +262,7 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
           {!hideTable && <TableBody />}
           <Chart />
         </main>
+        {!hideTable && <Divider />}
         {showBackToday && <TimeIndicator />}
         {showUnitSwitch && <TimeAxisScaleSelect />}
         <ScrollBar />

--- a/src/Gantt.tsx
+++ b/src/Gantt.tsx
@@ -79,6 +79,10 @@ export interface GanttProps<RecordType = DefaultRecordType> {
    * 隐藏左侧表格
    */
   hideTable?: boolean
+  tableSize?: {
+    minWidth?: number
+    maxWidth?: number
+  }
 }
 export interface GanttRef {
   backToday: () => void
@@ -155,6 +159,10 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
     customSights = [],
     locale = { ...defaultLocale },
     hideTable = false,
+    tableSize = {
+      minWidth: 500,
+      maxWidth: 890,
+    }
   } = props
 
   const store = useMemo(() => new GanttStore({ rowHeight, disabled, customSights, locale }), [rowHeight])
@@ -220,6 +228,7 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
       timeAxisMinorStyle,
       allowAddBar,
       hideTable,
+      tableSize
     }),
     [
       store,
@@ -247,6 +256,7 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
       timeAxisMinorStyle,
       allowAddBar,
       hideTable,
+      tableSize
     ]
   )
 

--- a/src/components/divider/index.tsx
+++ b/src/components/divider/index.tsx
@@ -10,7 +10,7 @@ const Divider: React.FC = () => {
   const prefixClsDivider = `${prefixCls}-divider`
   const { tableWidth } = store
 
-  // MEMO: 一旦コメントアウトで対応
+  // MEMO: 後々使用する可能性を考慮して一旦コメントアウトで対応
   // const handleClick = useCallback(
   //   (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
   //     event.stopPropagation()
@@ -56,7 +56,7 @@ const Divider: React.FC = () => {
         />
       )}
       <hr />
-      {/* MEMO: 一旦コメントアウトで対応 */}
+      {/* MEMO: 後々使用する可能性を考慮して一旦コメントアウトで対応 */}
       {/* {tableCollapseAble && (
         <div
           className={`${prefixClsDivider}-icon-wrapper`}

--- a/src/components/divider/index.tsx
+++ b/src/components/divider/index.tsx
@@ -6,17 +6,18 @@ import Context from '../../context'
 import './index.less'
 
 const Divider: React.FC = () => {
-  const { store, tableCollapseAble, prefixCls } = useContext(Context)
+  const { store, tableCollapseAble,tableSize, prefixCls } = useContext(Context)
   const prefixClsDivider = `${prefixCls}-divider`
   const { tableWidth } = store
 
-  const handleClick = useCallback(
-    (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-      event.stopPropagation()
-      store.toggleCollapse()
-    },
-    [store]
-  )
+  // MEMO: 一旦コメントアウトで対応
+  // const handleClick = useCallback(
+  //   (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+  //     event.stopPropagation()
+  //     store.toggleCollapse()
+  //   },
+  //   [store]
+  // )
   const left = tableWidth
 
   const handleResize = useCallback(
@@ -29,8 +30,8 @@ const Divider: React.FC = () => {
     initSize: {
       width: tableWidth,
     },
-    minWidth: 200,
-    maxWidth: store.width * 0.6,
+    minWidth: tableSize.minWidth,
+    maxWidth: tableSize.maxWidth,
   })
   return (
     <div
@@ -55,7 +56,8 @@ const Divider: React.FC = () => {
         />
       )}
       <hr />
-      {tableCollapseAble && (
+      {/* MEMO: 一旦コメントアウトで対応 */}
+      {/* {tableCollapseAble && (
         <div
           className={`${prefixClsDivider}-icon-wrapper`}
           role='none'
@@ -68,7 +70,7 @@ const Divider: React.FC = () => {
             })}
           />
         </div>
-      )}
+      )} */}
     </div>
   )
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -47,6 +47,10 @@ export interface GanttContext<RecordType = DefaultRecordType> {
   allowAddBar?: boolean
 
   hideTable?: boolean
+  tableSize?: {
+    minWidth?: number
+    maxWidth?: number
+  }
 }
 const context = createContext<GanttContext>({} as GanttContext)
 export default context

--- a/website/demo/basic.en-US.tsx
+++ b/website/demo/basic.en-US.tsx
@@ -78,7 +78,7 @@ function createData(len: number) {
 }
 
 const App = () => {
-  const [data, setData] = useState(createData(0))
+  const [data, setData] = useState(createData(10))
   console.log('data', data)
   const handleClick = (e) => {
     console.log(e, e.currentTarget.value, e.currentTarget.innerText)
@@ -91,9 +91,14 @@ const App = () => {
           {
             name: 'name',
             label: 'Custom Title',
+          },
+          {
+            name: 'name',
+            label: 'Custom Title',
             width: 100,
           },
         ]}
+        // onExpand={}
         unit='week_in_month'
         showUnitSwitch={false}
         locale={enUS}
@@ -115,7 +120,11 @@ const App = () => {
         renderDaysText={() => ''}
         showChangeBarSize={false}
         canMoveBar={false}
-        timeAxisMinorStyle={{ color: '#006ec8' }} 
+        timeAxisMinorStyle={{ color: '#006ec8' }}
+        tableSize={{
+          minWidth: 300,
+          maxWidth: 890,
+        }}
       />
     </div>
   )


### PR DESCRIPTION
## 変更内容

- テーブルのサイズを可変にできる Divider コンポーネントを復活
- `maxWidth` と `minWidth` を青売り側でコントロールできるように `props` で渡せるように変更


https://github.com/betterbound/react-gantt/assets/108515953/3b3e65de-6520-43e8-9f40-bfb0eef3d86d


## 確認項目

- [x] http://localhost:8000/#/en-US/component#component でタイトル箇所の可変ができる
- [x] `website/demo/basic.en-US.tsx` RcGantt コンポーネントの props `tableSize` で最大幅、最小幅の調整ができる

## 備考

ラインの太さや hover 時のカラー等の style はアプリ側で調整します。

## 共有
@shota8888 
タイトル横にドライバーを持ってくるのは少々込み入った対応になりそうだったので、ドライバーの位置はそのままでタイトルだけ可変するようにしました。