### PR TITLE
デフォルトの tableWidth を修正 

### DIFF
--- a/src/Gantt.tsx
+++ b/src/Gantt.tsx
@@ -159,13 +159,10 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
     customSights = [],
     locale = { ...defaultLocale },
     hideTable = false,
-    tableSize = {
-      minWidth: 500,
-      maxWidth: 890,
-    }
+    tableSize
   } = props
 
-  const store = useMemo(() => new GanttStore({ rowHeight, disabled, customSights, locale }), [rowHeight])
+  const store = useMemo(() => new GanttStore({ rowHeight, disabled, customSights, locale, tableSize }), [rowHeight])
   useEffect(() => {
     store.setData(data, startDateKey, endDateKey)
   }, [data, endDateKey, startDateKey, store])

--- a/src/components/divider/index.tsx
+++ b/src/components/divider/index.tsx
@@ -6,7 +6,7 @@ import Context from '../../context'
 import './index.less'
 
 const Divider: React.FC = () => {
-  const { store, tableCollapseAble,tableSize, prefixCls } = useContext(Context)
+  const { store, tableCollapseAble, tableSize, prefixCls } = useContext(Context)
   const prefixClsDivider = `${prefixCls}-divider`
   const { tableWidth } = store
 
@@ -30,8 +30,8 @@ const Divider: React.FC = () => {
     initSize: {
       width: tableWidth,
     },
-    minWidth: tableSize.minWidth,
-    maxWidth: tableSize.maxWidth,
+    minWidth: tableSize?.minWidth || 200,
+    maxWidth: tableSize?.maxWidth || store.width * 0.6,
   })
   return (
     <div

--- a/src/store.ts
+++ b/src/store.ts
@@ -71,11 +71,13 @@ class GanttStore {
     disabled = false,
     customSights,
     locale,
+    tableSize
   }: {
     rowHeight: number
     disabled: boolean
     customSights: Gantt.SightConfig[]
     locale: GanttLocale
+    tableSize: { minWidth?: number; maxWidth?: number }
   }) {
     this.width = 1320
     this.height = 418
@@ -86,7 +88,7 @@ class GanttStore {
     const viewWidth = 704
     const tableWidth = 500
     this.viewWidth = viewWidth
-    this.tableWidth = tableWidth
+    this.tableWidth = tableSize?.minWidth || tableWidth
     this.translateX = translateX
     this.sightConfig = sightConfig
     this.bodyWidth = bodyWidth

--- a/website/demo/basic.en-US.tsx
+++ b/website/demo/basic.en-US.tsx
@@ -91,11 +91,31 @@ const App = () => {
           {
             name: 'name',
             label: 'Custom Title',
+            width: 52,
+          },
+          {
+            name: 'name',
+            label: 'Custom Title',
+          },
+          {
+            name: 'name',
+            label: 'Custom Title',
+            width: 40,
+          },
+          {
+            name: 'name',
+            label: 'Custom Title',
+            width: 55,
           },
           {
             name: 'name',
             label: 'Custom Title',
             width: 100,
+          },
+          {
+            name: 'name',
+            label: 'Custom Title',
+            width: 85,
           },
         ]}
         // onExpand={}
@@ -122,8 +142,8 @@ const App = () => {
         canMoveBar={false}
         timeAxisMinorStyle={{ color: '#006ec8' }}
         tableSize={{
-          minWidth: 300,
-          maxWidth: 890,
+          minWidth: 684,
+          maxWidth: 1080,
         }}
       />
     </div>


### PR DESCRIPTION
## 概要

一部を可変可能にした時、デフォルトのテーブル幅が固定されていて、ページをリロードしたり最初にレンダリングされた際に設定した最小値で表示されない。

## 変更内容

tableSize の最小値が設定されているときは、そちらが有効になるように修正

### before


Uploading Screen Recording 2024-01-25 at 16.51.50.mov…


### after

https://github.com/betterbound/react-gantt/assets/108515953/6b4016b2-9ca7-4d16-8be5-52d287091a2e

## 確認項目
url: http://localhost:8000/#/en-US/component#component 
- [ ] after のように、リロードしてもテーブルサイズが tableSize の最小値になっている。